### PR TITLE
Add cfn-signal sleep time

### DIFF
--- a/cf-staging.yaml
+++ b/cf-staging.yaml
@@ -340,6 +340,7 @@ Resources:
           while [ $SECONDS -lt $end ] ; do
               wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
               if [ $? -eq "0" ] ; then
+                sleep 30
                 /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance1 --region ${AWS::Region}
               fi
           done
@@ -401,6 +402,7 @@ Resources:
           while [ $SECONDS -lt $end ] ; do
               wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
               if [ $? -eq "0" ] ; then
+                sleep 30
                 /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance2 --region ${AWS::Region}
               fi
           done

--- a/cf.yaml
+++ b/cf.yaml
@@ -340,6 +340,7 @@ Resources:
           while [ $SECONDS -lt $end ] ; do
               wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
               if [ $? -eq "0" ] ; then
+                sleep 30
                 /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance1 --region ${AWS::Region}
               fi
           done
@@ -401,6 +402,7 @@ Resources:
           while [ $SECONDS -lt $end ] ; do
               wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
               if [ $? -eq "0" ] ; then
+                sleep 30
                 /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance2 --region ${AWS::Region}
               fi
           done


### PR DESCRIPTION
## Purpose
> Add a sleep time of 30 seconds to ensure the carbon apps are deployed successfully.
