### PR TITLE
Remove EIP and change instance type

### DIFF
--- a/cf-staging.yaml
+++ b/cf-staging.yaml
@@ -290,10 +290,6 @@ Resources:
           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2BastionInstance --region ${AWS::Region}
   WSO2EIInstance1:
     Type: 'AWS::EC2::Instance'
-    CreationPolicy:
-      ResourceSignal:
-        Count: '1'
-        Timeout: PT15M
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
@@ -336,14 +332,6 @@ Resources:
           echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
           cat /dev/null > ~/.bash_history && history -c
           nohup /home/ubuntu/tailon alias=wso2_logs,/home/ubuntu/wso2ei-6.4.0/repository/logs/* > nohup.out 2>&1 &
-          end=$((SECONDS+600))
-          while [ $SECONDS -lt $end ] ; do
-              wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
-              if [ $? -eq "0" ] ; then
-                sleep 30
-                /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance1 --region ${AWS::Region}
-              fi
-          done
     DependsOn:
       - WSO2EILoadBalancer
       - WSO2EISecurityGroup
@@ -352,10 +340,6 @@ Resources:
       - WSO2BastionInstance
   WSO2EIInstance2:
     Type: 'AWS::EC2::Instance'
-    CreationPolicy:
-      ResourceSignal:
-        Count: '1'
-        Timeout: PT10M
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
@@ -398,14 +382,6 @@ Resources:
           echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
           cat /dev/null > ~/.bash_history && history -c
           nohup /home/ubuntu/tailon alias=wso2_logs,/home/ubuntu/wso2ei-6.4.0/repository/logs/* > nohup.out 2>&1 &
-          end=$((SECONDS+600))
-          while [ $SECONDS -lt $end ] ; do
-              wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
-              if [ $? -eq "0" ] ; then
-                sleep 30
-                /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance2 --region ${AWS::Region}
-              fi
-          done
     DependsOn:
       - WSO2EILoadBalancer
       - WSO2EISecurityGroup

--- a/cf-staging.yaml
+++ b/cf-staging.yaml
@@ -290,6 +290,10 @@ Resources:
           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2BastionInstance --region ${AWS::Region}
   WSO2EIInstance1:
     Type: 'AWS::EC2::Instance'
+    CreationPolicy:
+      ResourceSignal:
+        Count: '1'
+        Timeout: PT15M
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
@@ -332,6 +336,14 @@ Resources:
           echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
           cat /dev/null > ~/.bash_history && history -c
           nohup /home/ubuntu/tailon alias=wso2_logs,/home/ubuntu/wso2ei-6.4.0/repository/logs/* > nohup.out 2>&1 &
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ] ; do
+              wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
+              if [ $? -eq "0" ] ; then
+                sleep 30
+                /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance1 --region ${AWS::Region}
+              fi
+          done
     DependsOn:
       - WSO2EILoadBalancer
       - WSO2EISecurityGroup
@@ -340,6 +352,10 @@ Resources:
       - WSO2BastionInstance
   WSO2EIInstance2:
     Type: 'AWS::EC2::Instance'
+    CreationPolicy:
+      ResourceSignal:
+        Count: '1'
+        Timeout: PT10M
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
@@ -382,6 +398,14 @@ Resources:
           echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
           cat /dev/null > ~/.bash_history && history -c
           nohup /home/ubuntu/tailon alias=wso2_logs,/home/ubuntu/wso2ei-6.4.0/repository/logs/* > nohup.out 2>&1 &
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ] ; do
+              wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
+              if [ $? -eq "0" ] ; then
+                sleep 30
+                /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EIInstance2 --region ${AWS::Region}
+              fi
+          done
     DependsOn:
       - WSO2EILoadBalancer
       - WSO2EISecurityGroup

--- a/cf-staging.yaml
+++ b/cf-staging.yaml
@@ -148,19 +148,10 @@ Resources:
         - WSO2EIEIP
         - AllocationId
       SubnetId: !Ref WSO2EIPublicSubnet1
-#  WSO2BastionEIPAssociation:
-#    Type: 'AWS::EC2::EIPAssociation'
-#    Properties:
-#      AllocationId: !GetAtt WSO2BastionEIP.AllocationId
-#      InstanceId: !Ref WSO2BastionInstance
   WSO2EIEIP:
     Type: 'AWS::EC2::EIP'
     Properties:
       Domain: vpc
-#  WSO2BastionEIP:
-#    Type: 'AWS::EC2::EIP'
-#    Properties:
-#      Domain: vpc
   # database configurations
   WSO2EIDBInstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'

--- a/cf-staging.yaml
+++ b/cf-staging.yaml
@@ -148,19 +148,19 @@ Resources:
         - WSO2EIEIP
         - AllocationId
       SubnetId: !Ref WSO2EIPublicSubnet1
-  WSO2BastionEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      AllocationId: !GetAtt WSO2BastionEIP.AllocationId
-      InstanceId: !Ref WSO2BastionInstance
+#  WSO2BastionEIPAssociation:
+#    Type: 'AWS::EC2::EIPAssociation'
+#    Properties:
+#      AllocationId: !GetAtt WSO2BastionEIP.AllocationId
+#      InstanceId: !Ref WSO2BastionInstance
   WSO2EIEIP:
     Type: 'AWS::EC2::EIP'
     Properties:
       Domain: vpc
-  WSO2BastionEIP:
-    Type: 'AWS::EC2::EIP'
-    Properties:
-      Domain: vpc
+#  WSO2BastionEIP:
+#    Type: 'AWS::EC2::EIP'
+#    Properties:
+#      Domain: vpc
   # database configurations
   WSO2EIDBInstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -264,6 +264,7 @@ Resources:
           Value: WSO2BastionInstance
       NetworkInterfaces:
         - DeleteOnTermination: 'true'
+          AssociatePublicIpAddress : 'true'
           Description: Primary network interface
           DeviceIndex: 0
           SubnetId: !Ref WSO2EIPublicSubnet1

--- a/cf-staging.yaml
+++ b/cf-staging.yaml
@@ -677,6 +677,7 @@ Parameters:
       - m3.xlarge
       - m3.2xlarge
       - m4.large
+      - m4.xlarge
     ConstraintDescription: Must be a valid EC2 instance type
   DBUsername:
     Type: String

--- a/cf.yaml
+++ b/cf.yaml
@@ -148,19 +148,10 @@ Resources:
         - WSO2EIEIP
         - AllocationId
       SubnetId: !Ref WSO2EIPublicSubnet1
-#  WSO2BastionEIPAssociation:
-#    Type: 'AWS::EC2::EIPAssociation'
-#    Properties:
-#      AllocationId: !GetAtt WSO2BastionEIP.AllocationId
-#      InstanceId: !Ref WSO2BastionInstance
   WSO2EIEIP:
     Type: 'AWS::EC2::EIP'
     Properties:
       Domain: vpc
-#  WSO2BastionEIP:
-#    Type: 'AWS::EC2::EIP'
-#    Properties:
-#      Domain: vpc
   # database configurations
   WSO2EIDBInstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'

--- a/cf.yaml
+++ b/cf.yaml
@@ -148,19 +148,19 @@ Resources:
         - WSO2EIEIP
         - AllocationId
       SubnetId: !Ref WSO2EIPublicSubnet1
-  WSO2BastionEIPAssociation:
-    Type: 'AWS::EC2::EIPAssociation'
-    Properties:
-      AllocationId: !GetAtt WSO2BastionEIP.AllocationId
-      InstanceId: !Ref WSO2BastionInstance
+#  WSO2BastionEIPAssociation:
+#    Type: 'AWS::EC2::EIPAssociation'
+#    Properties:
+#      AllocationId: !GetAtt WSO2BastionEIP.AllocationId
+#      InstanceId: !Ref WSO2BastionInstance
   WSO2EIEIP:
     Type: 'AWS::EC2::EIP'
     Properties:
       Domain: vpc
-  WSO2BastionEIP:
-    Type: 'AWS::EC2::EIP'
-    Properties:
-      Domain: vpc
+#  WSO2BastionEIP:
+#    Type: 'AWS::EC2::EIP'
+#    Properties:
+#      Domain: vpc
   # database configurations
   WSO2EIDBInstanceSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -264,6 +264,7 @@ Resources:
           Value: WSO2BastionInstance
       NetworkInterfaces:
         - DeleteOnTermination: 'true'
+          AssociatePublicIpAddress : 'true'
           Description: Primary network interface
           DeviceIndex: 0
           SubnetId: !Ref WSO2EIPublicSubnet1

--- a/cf.yaml
+++ b/cf.yaml
@@ -677,6 +677,7 @@ Parameters:
       - m3.xlarge
       - m3.2xlarge
       - m4.large
+      - m4.xlarge
     ConstraintDescription: Must be a valid EC2 instance type
   DBUsername:
     Type: String


### PR DESCRIPTION
## Purpose
> change the instance type of stack instances to m4.xlarge and remove EIP created

## Goals
> get rid of unnecessary EIP creation
> resolve packer file provisioner intermittent hanging issue

## Approach
> remove EIP created for Bastion Instance
> add m4.xlarge to supported instance types